### PR TITLE
Add users CRUD, unified responses, migrations, tests, docs, and CI updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
             - uses: actions/setup-python@v5
               with:
                   python-version: "3.12"
-            - run: pip install --upgrade pip
-            - run: pip install -e ".[dev]"
-            - run: ruff check .
-            - run: black --check .
-            - run: PYTHONPATH=src pytest
+            - run: python -m pip install --upgrade pip
+            - run: python -m pip install -e ".[dev]"
+            - run: python -m ruff check .
+            - run: python -m black --check .
+            - run: python -m pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,16 @@ All notable changes to this project are documented in this file.
 
 ### Added
 
-- Initial Flask template baseline with app factory, health endpoint, tests, tooling, CI, docs, and container setup.
+- Users CRUD API module with create/get/list/update/delete endpoints under `/api/users`.
+- Unified API response and error schema helpers.
+- Initial Alembic migration for `users` table.
+- CRUD and error-case tests for users.
+
+### Changed
+
+- App factory now registers users blueprint and global error handlers.
+- CI workflow now runs tooling via `python -m ...` commands.
+- Documentation expanded for architecture, API usage, migrations, and PowerShell quickstart.
 
 ## [0.1.0] - 2026-02-27
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,43 +1,42 @@
 # Contributing
 
-Thanks for contributing.
+Thanks for investing time in this project.
 
-## Development Setup
-
-1. Create a virtual environment.
-2. Install dependencies.
-3. Copy environment variables.
+## Setup
 
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-pip install -e ".[dev]"
+python -m pip install --upgrade pip
+python -m pip install -e ".[dev]"
 cp .env.example .env
 ```
 
-## Run Locally
+PowerShell notes:
 
-```bash
-make run
+```powershell
+.\.venv\Scripts\Activate.ps1
+$env:PYTHONPATH="src"
 ```
 
-## Quality Checks
+## Run locally
 
 ```bash
-make lint
-make format
-make test
+PYTHONPATH=src python -m flask --app wsgi:app db upgrade
+PYTHONPATH=src python -m flask --app wsgi:app run --debug
 ```
 
-## Commit Guidelines
+## Quality gates
 
-- Use clear, imperative commit messages.
-- Keep commits focused and small.
-- Update tests and documentation with changes.
+```bash
+python -m ruff check .
+python -m black --check .
+python -m pytest
+```
+
+## Pull requests
+
+- Keep changes focused.
+- Add/adjust tests for behavior changes.
+- Update docs when behavior or setup changes.
 - Update `CHANGELOG.md` for user-visible changes.
-
-## Pull Request Guidelines
-
-- Fill out the PR template.
-- Ensure CI is green.
-- Describe intent, scope, and test evidence.

--- a/README.md
+++ b/README.md
@@ -1,74 +1,99 @@
 # Flask Forge Template
 
-A minimal, production-oriented Flask API template for fast project bootstrapping.
+Production-minded Flask API template with app factory, SQLAlchemy, migrations, test suite, and CI.
 
-## Features
+## What you get
 
-- Flask app factory and WSGI entrypoint
-- Health endpoint at `/api/health`
-- SQLAlchemy + Flask-Migrate wiring
-- Environment-based configuration
-- Structured logging setup
-- Pytest test suite
-- Ruff + Black code quality tooling
-- GitHub Actions CI
-- Docker and docker-compose support
+- App factory (`src/app.py`) + WSGI entrypoint (`src/wsgi.py`)
+- Health endpoint: `GET /api/health` -> `{"status":"ok"}`
+- Real CRUD example: `users` module (`POST/GET/LIST/PATCH/DELETE`)
+- Flask-SQLAlchemy + Flask-Migrate (SQLite by default)
+- Unified API success/error response format
+- Ruff + Black + Pytest + GitHub Actions CI
+- Docker and docker-compose for local development
 
-## Prerequisites
+## Requirements
 
 - Python 3.12+
 - pip
-- virtualenv (recommended)
 
-## Quickstart
+## Quickstart (PowerShell / Windows)
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+python -m pip install -e ".[dev]"
+Copy-Item .env.example .env
+$env:PYTHONPATH="src"
+python -m flask --app wsgi:app db upgrade
+python -m flask --app wsgi:app run --debug
+```
+
+## Quickstart (bash)
 
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-pip install -e ".[dev]"
+python -m pip install --upgrade pip
+python -m pip install -e ".[dev]"
 cp .env.example .env
-PYTHONPATH=src flask --app wsgi:app run --debug
+PYTHONPATH=src python -m flask --app wsgi:app db upgrade
+PYTHONPATH=src python -m flask --app wsgi:app run --debug
 ```
 
-API will be available at `http://127.0.0.1:5000`.
-
-## Development Commands
+## Quality checks
 
 ```bash
-make run
-make test
-make lint
-make format
+python -m ruff check .
+python -m black --check .
+python -m pytest
 ```
 
-## Environment Variables
+## API overview
 
-See `.env.example`.
+- `GET /api/health`
+- `POST /api/users`
+- `GET /api/users/{id}`
+- `GET /api/users?page=1&per_page=10`
+- `PATCH /api/users/{id}`
+- `DELETE /api/users/{id}`
 
-- `FLASK_ENV`: `development` | `testing` | `production`
-- `SECRET_KEY`: Flask secret key
-- `APP_NAME`: Application name
-- `DATABASE_URL`: SQLAlchemy database URL
-- `LOG_LEVEL`: Logging level (`DEBUG`, `INFO`, ...)
+See `docs/api.md` for full request/response examples.
 
-## Project Structure
+## Database migrations
+
+```bash
+PYTHONPATH=src python -m flask --app wsgi:app db upgrade
+PYTHONPATH=src python -m flask --app wsgi:app db migrate -m "message"
+```
+
+Alembic configuration is in `alembic.ini`, and migration scripts are under `src/migrations/versions`.
+
+## Project structure
 
 ```text
-.
-├── src/
-│   ├── api/
-│   ├── core/
-│   ├── db/
-│   ├── extensions/
-│   ├── utils/
-│   ├── app.py
-│   ├── config.py
-│   └── wsgi.py
-├── tests/
-├── docs/
-├── scripts/
-└── .github/workflows/
+src/
+  api/
+    health.py
+    users.py
+  core/
+  extensions/
+  app.py
+  config.py
+  wsgi.py
+tests/
+docs/
 ```
+
+## Documentation
+
+- `docs/index.md`
+- `docs/architecture.md`
+- `docs/configuration.md`
+- `docs/development.md`
+- `docs/api.md`
+- `docs/deployment.md`
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,23 +1,18 @@
 # Security Policy
 
-## Supported Versions
+## Supported versions
 
-Security updates are provided for the latest minor release.
+Security updates are provided for the latest release line.
 
-## Reporting a Vulnerability
+## Reporting a vulnerability
 
-Please report vulnerabilities privately by emailing: security@example.com
+Please report vulnerabilities privately to: `security@example.com`
 
 Include:
 
-- Affected version/commit
-- Reproduction steps
-- Impact assessment
-- Suggested remediation (if any)
+- affected version or commit
+- reproduction steps
+- expected impact
+- proof-of-concept if available
 
-## Disclosure Policy
-
-- We will acknowledge receipt within 5 business days.
-- We will investigate and validate findings.
-- We will coordinate a fix and release timeline.
-- We request responsible disclosure until a patch is available.
+We will acknowledge receipt, validate the issue, and coordinate a fix/release timeline.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,8 @@ services:
             - .env
         environment:
             DATABASE_URL: sqlite:////app/dev.db
+        volumes:
+            - ./:/app
+        command: >
+            sh -c "python -m flask --app wsgi:app db upgrade &&
+            gunicorn --bind 0.0.0.0:8000 --chdir src wsgi:app"

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,6 +2,71 @@
 
 ## Health
 
-- Method: `GET`
-- Path: `/api/health`
-- Response: `{"status":"ok"}`
+### `GET /api/health`
+
+Response:
+
+```json
+{"status": "ok"}
+```
+
+## Users
+
+Base schema for successful responses:
+
+```json
+{
+    "success": true,
+    "data": {},
+    "meta": {}
+}
+```
+
+Base schema for error responses:
+
+```json
+{
+    "success": false,
+    "error": {
+        "code": "invalid_payload",
+        "message": "Request body is required."
+    }
+}
+```
+
+### `POST /api/users`
+
+Request:
+
+```json
+{
+    "email": "john@example.com",
+    "full_name": "John Doe",
+    "is_active": true
+}
+```
+
+### `GET /api/users/{id}`
+
+Returns a single user.
+
+### `GET /api/users?page=1&per_page=10`
+
+Returns paginated users with `meta`:
+
+```json
+{
+    "page": 1,
+    "per_page": 10,
+    "total": 1,
+    "pages": 1
+}
+```
+
+### `PATCH /api/users/{id}`
+
+Allowed fields: `email`, `full_name`, `is_active`.
+
+### `DELETE /api/users/{id}`
+
+Returns HTTP `204 No Content`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,8 +1,23 @@
 # Architecture
 
-- Flask app factory in `src/app.py`
-- WSGI entrypoint in `src/wsgi.py`
-- API routes under `src/api`
-- Core concerns in `src/core`
-- Extensions in `src/extensions`
-- Database helpers in `src/db`
+## Runtime layout
+
+- `src/app.py`: application factory and extension/blueprint registration.
+- `src/wsgi.py`: WSGI entrypoint.
+- `src/config.py`: environment-aware config classes.
+- `src/api/`: API modules (`health`, `users`).
+- `src/core/`: shared concerns (logging, errors, response schema).
+- `src/extensions/`: integration points for db/migrations/cors/jwt placeholder.
+
+## Request flow
+
+1. `create_app` loads selected config.
+2. Extensions are initialized (`db`, `migrate`, `cors`, `jwt placeholder`).
+3. Blueprints are mounted under `/api`.
+4. Errors are normalized by `core.errors.register_error_handlers`.
+
+## Data layer
+
+- SQLAlchemy model `User` lives in `src/api/users.py`.
+- SQLite is default for local dev.
+- Migrations are managed through Flask-Migrate + Alembic.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,11 +1,18 @@
 # Configuration
 
-Environment variables:
+## Environment variables
 
-- `FLASK_ENV`
-- `SECRET_KEY`
-- `APP_NAME`
-- `DATABASE_URL`
-- `LOG_LEVEL`
+- `FLASK_ENV`: `development`, `testing`, `production`
+- `APP_NAME`: app name used in config
+- `SECRET_KEY`: Flask secret key
+- `DATABASE_URL`: SQLAlchemy connection string
+- `LOG_LEVEL`: logging level, default `INFO`
 
-Default local database is SQLite.
+## Defaults
+
+- Development DB: `sqlite:///./dev.db`
+- Testing DB: in-memory SQLite
+
+## Config selection
+
+`get_config` selects config from explicit app-factory argument first, then `FLASK_ENV`, and falls back to development.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -7,8 +7,10 @@ docker build -t flask-forge-template .
 docker run --rm -p 8000:8000 --env-file .env flask-forge-template
 ```
 
-## Compose
+## Docker Compose
 
 ```bash
 docker compose up --build
 ```
+
+The image starts Gunicorn on port `8000` and serves `wsgi:app` from `src`.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,15 +1,33 @@
 # Development
 
+## Local setup
+
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-pip install -e ".[dev]"
+python -m pip install --upgrade pip
+python -m pip install -e ".[dev]"
 cp .env.example .env
+PYTHONPATH=src python -m flask --app wsgi:app db upgrade
 ```
 
-Commands:
+## Run app
 
-- `make run`
-- `make test`
-- `make lint`
-- `make format`
+```bash
+PYTHONPATH=src python -m flask --app wsgi:app run --debug
+```
+
+## Run checks
+
+```bash
+python -m ruff check .
+python -m black --check .
+python -m pytest
+```
+
+## Creating a migration
+
+```bash
+PYTHONPATH=src python -m flask --app wsgi:app db migrate -m "describe change"
+PYTHONPATH=src python -m flask --app wsgi:app db upgrade
+```

--- a/src/api/users.py
+++ b/src/api/users.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from typing import Any
+
+from flask import Blueprint, request
+
+from core.errors import APIError
+from core.responses import created_response, no_content_response, success_response
+from extensions.db import db
+
+users_bp = Blueprint("users", __name__)
+
+
+class User(db.Model):
+    __tablename__ = "users"
+
+    id = db.Column(db.Integer, primary_key=True)
+    email = db.Column(db.String(255), unique=True, nullable=False, index=True)
+    full_name = db.Column(db.String(255), nullable=False)
+    is_active = db.Column(db.Boolean, nullable=False, default=True)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "email": self.email,
+            "full_name": self.full_name,
+            "is_active": self.is_active,
+        }
+
+
+def _validate_create_payload(payload: dict[str, Any] | None) -> tuple[str, str, bool]:
+    if not payload:
+        raise APIError("invalid_payload", "Request body is required.", 400)
+
+    email = str(payload.get("email", "")).strip().lower()
+    full_name = str(payload.get("full_name", "")).strip()
+    is_active = payload.get("is_active", True)
+
+    if not email or "@" not in email:
+        raise APIError("invalid_email", "A valid email is required.", 400)
+    if not full_name:
+        raise APIError("invalid_full_name", "full_name is required.", 400)
+    if not isinstance(is_active, bool):
+        raise APIError("invalid_is_active", "is_active must be a boolean.", 400)
+
+    return email, full_name, is_active
+
+
+def _validate_patch_payload(payload: dict[str, Any] | None) -> dict[str, Any]:
+    if not payload:
+        raise APIError("invalid_payload", "Request body is required.", 400)
+
+    allowed_keys = {"email", "full_name", "is_active"}
+    invalid_keys = set(payload) - allowed_keys
+    if invalid_keys:
+        raise APIError("invalid_fields", "Unsupported fields were provided.", 400)
+
+    updates: dict[str, Any] = {}
+
+    if "email" in payload:
+        email = str(payload["email"]).strip().lower()
+        if not email or "@" not in email:
+            raise APIError("invalid_email", "A valid email is required.", 400)
+        updates["email"] = email
+
+    if "full_name" in payload:
+        full_name = str(payload["full_name"]).strip()
+        if not full_name:
+            raise APIError("invalid_full_name", "full_name cannot be empty.", 400)
+        updates["full_name"] = full_name
+
+    if "is_active" in payload:
+        is_active = payload["is_active"]
+        if not isinstance(is_active, bool):
+            raise APIError("invalid_is_active", "is_active must be a boolean.", 400)
+        updates["is_active"] = is_active
+
+    if not updates:
+        raise APIError("empty_update", "At least one valid field must be provided.", 400)
+
+    return updates
+
+
+def _get_user_or_404(user_id: int) -> User:
+    user = db.session.get(User, user_id)
+    if user is None:
+        raise APIError("not_found", "User not found.", 404)
+    return user
+
+
+@users_bp.post("/users")
+def create_user():
+    email, full_name, is_active = _validate_create_payload(request.get_json(silent=True))
+
+    if User.query.filter_by(email=email).first() is not None:
+        raise APIError("email_conflict", "User with this email already exists.", 409)
+
+    user = User(email=email, full_name=full_name, is_active=is_active)
+    db.session.add(user)
+    db.session.commit()
+
+    return created_response(user.to_dict())
+
+
+@users_bp.get("/users/<int:user_id>")
+def get_user(user_id: int):
+    user = _get_user_or_404(user_id)
+    return success_response(user.to_dict())
+
+
+@users_bp.get("/users")
+def list_users():
+    page = request.args.get("page", default=1, type=int)
+    per_page = request.args.get("per_page", default=10, type=int)
+
+    if page < 1 or per_page < 1:
+        raise APIError("invalid_pagination", "page and per_page must be positive integers.", 400)
+
+    pagination = User.query.order_by(User.id.asc()).paginate(
+        page=page,
+        per_page=min(per_page, 100),
+        error_out=False,
+    )
+
+    return success_response(
+        [user.to_dict() for user in pagination.items],
+        meta={
+            "page": pagination.page,
+            "per_page": pagination.per_page,
+            "total": pagination.total,
+            "pages": pagination.pages,
+        },
+    )
+
+
+@users_bp.patch("/users/<int:user_id>")
+def update_user(user_id: int):
+    user = _get_user_or_404(user_id)
+    updates = _validate_patch_payload(request.get_json(silent=True))
+
+    if "email" in updates:
+        existing = User.query.filter(User.email == updates["email"], User.id != user.id).first()
+        if existing is not None:
+            raise APIError("email_conflict", "User with this email already exists.", 409)
+
+    for field_name, value in updates.items():
+        setattr(user, field_name, value)
+
+    db.session.commit()
+    return success_response(user.to_dict())
+
+
+@users_bp.delete("/users/<int:user_id>")
+def delete_user(user_id: int):
+    user = _get_user_or_404(user_id)
+    db.session.delete(user)
+    db.session.commit()
+    return no_content_response()

--- a/src/app.py
+++ b/src/app.py
@@ -1,7 +1,9 @@
 from flask import Flask
 
 from api.health import health_bp
+from api.users import users_bp
 from config import get_config
+from core.errors import register_error_handlers
 from core.logging import configure_logging
 from extensions.cors import init_cors
 from extensions.db import db
@@ -20,5 +22,7 @@ def create_app(config_name: str | None = None) -> Flask:
     init_cors(app)
 
     app.register_blueprint(health_bp, url_prefix="/api")
+    app.register_blueprint(users_bp, url_prefix="/api")
+    register_error_handlers(app)
 
     return app

--- a/src/core/errors.py
+++ b/src/core/errors.py
@@ -1,7 +1,30 @@
-from flask import jsonify
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from werkzeug.exceptions import HTTPException
+
+from core.responses import error_response
+
+
+@dataclass
+class APIError(Exception):
+    code: str
+    message: str
+    status_code: int = 400
+    details: dict[str, Any] | None = None
 
 
 def register_error_handlers(app):
-    @app.errorhandler(404)
-    def not_found(_error):
-        return jsonify({"error": "not found"}), 404
+    @app.errorhandler(APIError)
+    def handle_api_error(error: APIError):
+        return error_response(error.code, error.message, error.status_code, error.details)
+
+    @app.errorhandler(HTTPException)
+    def handle_http_exception(error: HTTPException):
+        return error_response("http_error", error.description, error.code or 500)
+
+    @app.errorhandler(Exception)
+    def handle_unexpected_error(_error: Exception):
+        return error_response("internal_error", "Internal server error.", 500)

--- a/src/core/responses.py
+++ b/src/core/responses.py
@@ -1,5 +1,35 @@
+from __future__ import annotations
+
+from typing import Any
+
 from flask import jsonify
 
 
-def ok(payload: dict):
-    return jsonify(payload), 200
+def success_response(data: Any, status_code: int = 200, meta: dict[str, Any] | None = None):
+    payload: dict[str, Any] = {"success": True, "data": data}
+    if meta is not None:
+        payload["meta"] = meta
+    return jsonify(payload), status_code
+
+
+def created_response(data: Any):
+    return success_response(data, status_code=201)
+
+
+def no_content_response():
+    return "", 204
+
+
+def error_response(
+    code: str, message: str, status_code: int, details: dict[str, Any] | None = None
+):
+    payload: dict[str, Any] = {
+        "success": False,
+        "error": {
+            "code": code,
+            "message": message,
+        },
+    }
+    if details:
+        payload["error"]["details"] = details
+    return jsonify(payload), status_code

--- a/src/migrations/versions/20260227_000001_create_users_table.py
+++ b/src/migrations/versions/20260227_000001_create_users_table.py
@@ -1,0 +1,31 @@
+"""create users table
+
+Revision ID: 20260227_000001
+Revises:
+Create Date: 2026-02-27 00:00:01.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260227_000001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("email", sa.String(length=255), nullable=False),
+        sa.Column("full_name", sa.String(length=255), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_users_email"), "users", ["email"], unique=True)
+
+
+def downgrade():
+    op.drop_index(op.f("ix_users_email"), table_name="users")
+    op.drop_table("users")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,24 @@
-import os
+from __future__ import annotations
+
+import sys
+from pathlib import Path
 
 import pytest
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
 from app import create_app
+from extensions.db import db
 
 
 @pytest.fixture()
 def app():
-    os.environ["FLASK_ENV"] = "testing"
     app = create_app("testing")
-    yield app
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
 
 
 @pytest.fixture()

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,0 +1,58 @@
+def test_users_crud_flow(client):
+    create_response = client.post(
+        "/api/users",
+        json={"email": "first@example.com", "full_name": "First User"},
+    )
+    assert create_response.status_code == 201
+    created_data = create_response.get_json()["data"]
+    user_id = created_data["id"]
+    assert created_data["email"] == "first@example.com"
+
+    get_response = client.get(f"/api/users/{user_id}")
+    assert get_response.status_code == 200
+    assert get_response.get_json()["data"]["full_name"] == "First User"
+
+    list_response = client.get("/api/users?page=1&per_page=5")
+    assert list_response.status_code == 200
+    payload = list_response.get_json()
+    assert payload["meta"]["page"] == 1
+    assert payload["meta"]["per_page"] == 5
+    assert payload["meta"]["total"] == 1
+
+    patch_response = client.patch(
+        f"/api/users/{user_id}",
+        json={"full_name": "Updated User", "is_active": False},
+    )
+    assert patch_response.status_code == 200
+    updated = patch_response.get_json()["data"]
+    assert updated["full_name"] == "Updated User"
+    assert updated["is_active"] is False
+
+    delete_response = client.delete(f"/api/users/{user_id}")
+    assert delete_response.status_code == 204
+
+    get_after_delete = client.get(f"/api/users/{user_id}")
+    assert get_after_delete.status_code == 404
+
+
+def test_users_error_cases(client):
+    invalid_create = client.post("/api/users", json={"email": "bad", "full_name": ""})
+    assert invalid_create.status_code == 400
+
+    first_create = client.post(
+        "/api/users",
+        json={"email": "duplicate@example.com", "full_name": "Name"},
+    )
+    assert first_create.status_code == 201
+
+    duplicate_create = client.post(
+        "/api/users",
+        json={"email": "duplicate@example.com", "full_name": "Name 2"},
+    )
+    assert duplicate_create.status_code == 409
+
+    invalid_patch = client.patch("/api/users/1", json={"is_active": "yes"})
+    assert invalid_patch.status_code == 400
+
+    invalid_pagination = client.get("/api/users?page=0&per_page=10")
+    assert invalid_pagination.status_code == 400


### PR DESCRIPTION
### Motivation
- Provide a production-minded Flask API template by filling missing pieces (real feature example, consistent responses, migrations, tests, docs, and CI tweaks). 
- Make the project runnable and testable out-of-the-box on Python 3.12 including PowerShell/Windows quickstart semantics. 

### Description
- Added a real Users CRUD module at `src/api/users.py` with SQLAlchemy model, input validation, and endpoints `POST /api/users`, `GET /api/users/{id}`, `GET /api/users` (pagination), `PATCH /api/users/{id}`, and `DELETE /api/users/{id}`. 
- Introduced unified response helpers and centralized error handling in `src/core/responses.py` and `src/core/errors.py`, and registered the handlers in the app factory (`src/app.py`). 
- Added an Alembic migration `src/migrations/versions/20260227_000001_create_users_table.py` for the `users` table and updated docs/README with migration usage and PowerShell quickstart. 
- Added/updated tests and test bootstrapping: improved `tests/conftest.py` to import the app directly from `src`, added `tests/test_users.py` (happy path + error cases), and kept `tests/test_health.py`; updated CI workflow to run tooling via `python -m ...` commands and refreshed docs/CONTRIBUTING/CHANGELOG/SECURITY/docker-compose accordingly. 

### Testing
- Installed dev dependencies with `python -m pip install -e

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1f243778083329d091f6296379016)